### PR TITLE
api.listen depreciated in favour of api.listenMqtt

### DIFF
--- a/src/messen.ts
+++ b/src/messen.ts
@@ -136,7 +136,7 @@ export class Messen {
   }
 
   listen(): void {
-    this.api.listen((err, ev) => {
+    this.api.listenMqtt((err, ev) => {
       if (err) {
         return logger.info(err.error);
       }

--- a/src/types/facebook-chat-api.d.ts
+++ b/src/types/facebook-chat-api.d.ts
@@ -98,7 +98,7 @@ declare namespace Facebook {
     ["INBOX", "unread"] | ["ARCHIVED", "unread"] | ["PENDING", "unread"] | ["OTHER", "unread"]
 
   export class API {
-    listen(
+    listenMqtt(
       callback: (err: Facebook.FacebookError | undefined, event: Facebook.APIEvent) => void,
     ): void;
     getCurrentUserID(): string;


### PR DESCRIPTION
It looks like recently the Facebook API changed to use a different messaging protocol called MQTT. The facebook-chat-api library updated to include this change by depreciating ```api.listen``` in favour of ```api.listenMqtt```. According to their docs, it's mostly a drop-in replacement.

More on the API change can be found [in the docs](https://github.com/Schmavery/facebook-chat-api/blob/9e949adaa3fbcd09725fa54e49406949726e2534/DOCS.md#listenMqtt) as well as in in [issue #763](https://github.com/Schmavery/facebook-chat-api/issues/763).

This pull request also solves [issue #137 in the Messer repo](https://github.com/mjkaufer/Messer/issues/137) where new messages were not being received after login to Messer.